### PR TITLE
changes prototype of amd_mp2_device_match to match kernel 5.3

### DIFF
--- a/i2c-amd-mp2-pci.c
+++ b/i2c-amd-mp2-pci.c
@@ -662,7 +662,7 @@ static struct pci_driver amd_mp2_pci_driver = {
 #endif
 };
 
-static int amd_mp2_device_match(struct device *dev, void *data)
+static int amd_mp2_device_match(struct device *dev, const void *data)
 {
 	return 1;
 }


### PR DESCRIPTION
declaration is different in device.h, and this prevents the build from
running because it is treated as a different pointer type

(on my debian laptop running kernel 5.3.0-2-amd64 from linux-image package)